### PR TITLE
enhancement: LLM-as-Judge evaluation mode

### DIFF
--- a/backend/agent_runner.py
+++ b/backend/agent_runner.py
@@ -1,9 +1,10 @@
 import time
-import os
+import json
+import re
+from openai import OpenAI
 from db import get_db
-from schemas import AgentConfig
 
-async def run_test_case(test_case_id: int, config: AgentConfig):
+async def run_test_case(test_case_id: int, api_url: str, api_key: str, model: str, system_prompt: str):
     # Get test case
     with get_db() as db:
         row = db.execute('SELECT * FROM test_cases WHERE id = ?', (test_case_id,)).fetchone()
@@ -11,57 +12,137 @@ async def run_test_case(test_case_id: int, config: AgentConfig):
             raise ValueError(f"Test case {test_case_id} not found")
         test_case = dict(row)
 
-    # Run agent
-    start = time.time()
+    start_time = time.time()
+    output = None
+    error = None
+    status = "passed"
+    judge_score = None
+    judge_reason = None
+
     try:
         # Build messages
-        # Use test case's system_prompt if provided, else config's
-        system_prompt = test_case.get('system_prompt') or config.system_prompt
         messages = [
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": system_prompt or test_case['system_prompt'] or "You are a helpful AI assistant."},
             {"role": "user", "content": test_case['input_prompt']}
         ]
 
-        # Call OpenAI-compatible API
-        from openai import OpenAI
-        base_url = config.api_url if hasattr(config, 'api_url') else "https://openrouter.ai/api/v1"
-        client = OpenAI(api_key=config.api_key, base_url=base_url)
+        # Call LLM API
+        client = OpenAI(api_key=api_key, base_url=api_url)
 
         response = client.chat.completions.create(
-            model=config.model,
+            model=model,
             messages=messages,
             max_tokens=2048,
             temperature=0.3
         )
 
         output = response.choices[0].message.content
-        duration_ms = int((time.time() - start) * 1000)
+        duration_ms = int((time.time() - start_time) * 1000)
 
-        # Check expected keywords
-        keywords = [k.strip().lower() for k in test_case['expected_keywords'].split(',') if k.strip()]
-        passed = all(kw in output.lower() for kw in keywords) if keywords else True
-
-        status = "passed" if passed else "failed"
-        error = None
-
-        # Save run
-        with get_db() as db:
-            cursor = db.execute('''
-                INSERT INTO test_runs (test_case_id, status, output, duration_ms, error)
-                VALUES (?, ?, ?, ?, ?)
-            ''', (test_case_id, status, output[:10000], duration_ms, error))
-            db.commit()
-            run_id = cursor.lastrowid
-
-        return {"run_id": run_id, "status": status, "output": output, "duration_ms": duration_ms}
+        # Evaluate based on eval_mode
+        eval_mode = test_case.get('eval_mode', 'keyword')
+        
+        if eval_mode == 'judge':
+            # LLM-as-Judge evaluation
+            judge_score, judge_reason = await _evaluate_with_judge(
+                prompt=test_case['input_prompt'],
+                response=output,
+                judge_model=test_case.get('judge_model', 'openai/gpt-4o-mini'),
+                judge_threshold=test_case.get('judge_threshold', 7.0),
+                judge_prompt=test_case.get('judge_prompt'),
+                client=client
+            )
+            
+            threshold = judge_threshold
+            status = "passed" if judge_score >= threshold else "failed"
+            status = status
+        else:
+            # Keyword-based evaluation (original)
+            keywords = [k.strip().lower() for k in test_case['expected_keywords'].split(',') if k.strip()]
+            if keywords:
+                output_lower = output.lower()
+                missing = [kw for kw in keywords if kw not in output_lower]
+                if missing:
+                    status = "failed"
+                    error = f"Missing keywords: {', '.join(missing)}"
 
     except Exception as e:
-        duration_ms = int((time.time() - start) * 1000)
-        with get_db() as db:
-            cursor = db.execute('''
-                INSERT INTO test_runs (test_case_id, status, error, duration_ms)
-                VALUES (?, ?, ?, ?)
-            ''', (test_case_id, "error", str(e), duration_ms))
-            db.commit()
-            run_id = cursor.lastrowid
-        return {"run_id": run_id, "status": "error", "error": str(e)}
+        duration_ms = int((time.time() - start_time) * 1000)
+        status = "error"
+        error = str(e)
+        output = None
+
+    # Save run
+    with get_db() as db:
+        cursor = db.execute('''
+            INSERT INTO test_runs (test_case_id, status, output, duration_ms, error, model, api_url, judge_score, judge_reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (test_case_id, status, output[:20000] if output else None, duration_ms, error, model, api_url, judge_score, judge_reason))
+        db.commit()
+        run_id = cursor.lastrowid
+
+    return {
+        "id": run_id,
+        "test_case_id": test_case_id,
+        "status": status,
+        "output": output,
+        "duration_ms": duration_ms,
+        "error": error,
+        "model": model,
+        "judge_score": judge_score,
+        "judge_reason": judge_reason
+    }
+
+
+async def _evaluate_with_judge(prompt: str, response: str, judge_model: str, judge_threshold: float, judge_prompt: str, client) -> tuple:
+    """
+    Use an LLM as a judge to evaluate the agent's response.
+    Returns (score: float, reason: str)
+    """
+    system_prompt = judge_prompt or """You are an impartial AI judge. Evaluate the response to the given prompt.
+
+Score the response on THREE dimensions (each 0-10):
+1. accuracy - Is the information factually correct?
+2. relevance - Does it directly address the user's question?
+3. helpfulness - Is it clear, complete, and useful?
+
+Return ONLY valid JSON with this structure:
+{"accuracy": 8, "relevance": 9, "helpfulness": 7, "overall": 8, "reason": "brief explanation"}
+
+Overall score is a weighted average: accuracy(40%) + relevance(30%) + helpfulness(30%).
+JSON OUTPUT ONLY — no markdown, no explanation outside the JSON."""
+
+    judge_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": f"Prompt: {prompt}\n\nResponse to evaluate: {response}"}
+    ]
+
+    try:
+        judge_response = client.chat.completions.create(
+            model=judge_model,
+            messages=judge_messages,
+            max_tokens=512,
+            temperature=0.2
+        )
+
+        judge_text = judge_response.choices[0].message.content.strip()
+        
+        # Parse JSON from judge response
+        # Handle cases where model wraps in ```json block
+        json_match = re.search(r'\{[^{}]*"overall"[^{}]*\}', judge_text, re.DOTALL)
+        if json_match:
+            judge_data = json.loads(json_match.group())
+            score = float(judge_data.get('overall', 0))
+            reason = judge_data.get('reason', '')
+            return score, reason
+        else:
+            # Try parsing entire response as JSON
+            try:
+                judge_data = json.loads(judge_text)
+                score = float(judge_data.get('overall', 0))
+                reason = judge_data.get('reason', '')
+                return score, reason
+            except Exception:
+                return 0.0, f"Could not parse judge output: {judge_text[:100]}"
+    except Exception as e:
+        return 0.0, f"Judge error: {str(e)}"

--- a/backend/db.py
+++ b/backend/db.py
@@ -17,8 +17,12 @@ def init_db():
             name TEXT NOT NULL,
             description TEXT,
             input_prompt TEXT NOT NULL,
-            expected_keywords TEXT,
+            expected_keywords TEXT DEFAULT '',
             system_prompt TEXT DEFAULT '',
+            eval_mode TEXT DEFAULT 'keyword',
+            judge_model TEXT DEFAULT 'openai/gpt-4o-mini',
+            judge_threshold REAL DEFAULT 7.0,
+            judge_prompt TEXT DEFAULT '',
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
 
@@ -32,21 +36,33 @@ def init_db():
             error TEXT,
             model TEXT,
             api_url TEXT,
+            judge_score REAL,
+            judge_reason TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (test_case_id) REFERENCES test_cases(id)
         );
         ''')
-        # Migration: add system_prompt column if missing (existing dbs)
-        try:
-            db.execute('ALTER TABLE test_cases ADD COLUMN system_prompt TEXT DEFAULT ""')
-        except Exception:
-            pass
-        try:
-            db.execute('ALTER TABLE test_runs ADD COLUMN model TEXT')
-        except Exception:
-            pass
-        try:
-            db.execute('ALTER TABLE test_runs ADD COLUMN api_url TEXT')
-        except Exception:
-            pass
-        ''')
+        
+        # Migrations for existing databases
+        for col, dtype, default in [
+            ('system_prompt', 'TEXT', '""'),
+            ('eval_mode', 'TEXT', '"keyword"'),
+            ('judge_model', 'TEXT', '"openai/gpt-4o-mini"'),
+            ('judge_threshold', 'REAL', '7.0'),
+            ('judge_prompt', 'TEXT', '""'),
+        ]:
+            try:
+                db.execute(f'ALTER TABLE test_cases ADD COLUMN {col} {dtype} DEFAULT {default}')
+            except Exception:
+                pass
+        
+        for col, dtype, default in [
+            ('model', 'TEXT', 'NULL'),
+            ('api_url', 'TEXT', 'NULL'),
+            ('judge_score', 'REAL', 'NULL'),
+            ('judge_reason', 'TEXT', 'NULL'),
+        ]:
+            try:
+                db.execute(f'ALTER TABLE test_runs ADD COLUMN {col} {dtype} DEFAULT {default}')
+            except Exception:
+                pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,25 +12,44 @@ init_db()
 def create_test_case(data: TestCaseCreate):
     with get_db() as db:
         cursor = db.execute('''
-            INSERT INTO test_cases (name, description, input_prompt, expected_keywords, system_prompt)
-            VALUES (?, ?, ?, ?, ?)
-        ''', (data.name, data.description, data.input_prompt, data.expected_keywords, data.system_prompt))
+            INSERT INTO test_cases (name, description, input_prompt, expected_keywords, system_prompt, eval_mode, judge_model, judge_threshold, judge_prompt)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            data.name, data.description, data.input_prompt, data.expected_keywords,
+            data.system_prompt, data.eval_mode, data.judge_model,
+            data.judge_threshold, data.judge_prompt
+        ))
         db.commit()
         return {"id": cursor.lastrowid}
 
 @app.get("/api/test-cases")
 def list_test_cases(skip: int = 0, limit: int = 50):
     with get_db() as db:
-        rows = db.execute('SELECT * FROM test_cases ORDER BY created_at DESC LIMIT ? OFFSET ?', (limit, skip)).fetchall()
+        rows = db.execute(
+            'SELECT * FROM test_cases ORDER BY created_at DESC LIMIT ? OFFSET ?',
+            (limit, skip)
+        ).fetchall()
         return [dict(r) for r in rows]
+
+@app.get("/api/test-cases/{test_id}")
+def get_test_case(test_id: int):
+    with get_db() as db:
+        row = db.execute('SELECT * FROM test_cases WHERE id = ?', (test_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Test case not found")
+        return dict(row)
 
 @app.put("/api/test-cases/{id}")
 def update_test_case(id: int, data: TestCaseCreate):
     with get_db() as db:
         cursor = db.execute('''
-            UPDATE test_cases SET name=?, description=?, input_prompt=?, expected_keywords=?, system_prompt=?
+            UPDATE test_cases SET name=?, description=?, input_prompt=?, expected_keywords=?, system_prompt=?, eval_mode=?, judge_model=?, judge_threshold=?, judge_prompt=?
             WHERE id=?
-        ''', (data.name, data.description, data.input_prompt, data.expected_keywords, data.system_prompt, id))
+        ''', (
+            data.name, data.description, data.input_prompt, data.expected_keywords,
+            data.system_prompt, data.eval_mode, data.judge_model,
+            data.judge_threshold, data.judge_prompt, id
+        ))
         db.commit()
         if cursor.rowcount == 0:
             raise HTTPException(404, "Test case not found")
@@ -49,12 +68,13 @@ def delete_test_case(id: int):
 def create_run(data: TestRunRequest):
     from agent_runner import run_test_case
     import asyncio
-    return asyncio.run(run_test_case(data.test_case_id, AgentConfig(
-        model=data.model,
-        api_key=data.api_key or os.getenv("OPENAI_API_KEY", ""),
-        api_url=data.api_url,
-        system_prompt=data.system_prompt or "You are a helpful AI assistant."
-    )))
+    return asyncio.run(run_test_case(
+        data.test_case_id,
+        data.api_url,
+        data.api_key or os.getenv("OPENAI_API_KEY", ""),
+        data.model,
+        data.system_prompt or "You are a helpful AI assistant."
+    ))
 
 @app.get("/api/runs")
 def list_runs(test_case_id: int = None, skip: int = 0, limit: int = 50):
@@ -82,7 +102,7 @@ def list_runs(test_case_id: int = None, skip: int = 0, limit: int = 50):
 def get_run(run_id: int):
     with get_db() as db:
         row = db.execute('''
-            SELECT r.*, t.name, t.description, t.input_prompt, t.expected_keywords
+            SELECT r.*, t.name, t.description, t.input_prompt, t.expected_keywords, t.eval_mode, t.judge_model, t.judge_threshold
             FROM test_runs r
             JOIN test_cases t ON r.test_case_id = t.id
             WHERE r.id = ?
@@ -98,9 +118,9 @@ def get_stats():
         runs = db.execute('SELECT COUNT(*) as c FROM test_runs').fetchone()['c']
         passed = db.execute("SELECT COUNT(*) as c FROM test_runs WHERE status='passed'").fetchone()['c']
         failed = db.execute("SELECT COUNT(*) as c FROM test_runs WHERE status='failed'").fetchone()['c']
-        error = db.execute("SELECT COUNT(*) as c FROM test_runs WHERE status='error'").fetchone()['c']
+        errors = db.execute("SELECT COUNT(*) as c FROM test_runs WHERE status='error'").fetchone()['c']
         pass_rate = round(100 * passed / runs, 1) if runs > 0 else 0
-        return {"total_cases": total, "total_runs": runs, "passed": passed, "failed": failed, "errors": error, "pass_rate": pass_rate}
+        return {"total_cases": total, "total_runs": runs, "passed": passed, "failed": failed, "errors": errors, "pass_rate": pass_rate}
 
 # --- Frontend static files ---
 frontend_dir = os.path.join(os.path.dirname(__file__), '..', 'frontend')

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -5,8 +5,13 @@ class TestCaseCreate(BaseModel):
     name: str
     description: str = ""
     input_prompt: str
-    expected_keywords: str = ""  # comma-separated
+    expected_keywords: str = ""  # comma-separated (fallback if no judge)
     system_prompt: str = ""
+    # LLM judge settings
+    eval_mode: str = "keyword"  # "keyword" | "judge"
+    judge_model: str = "openai/gpt-4o-mini"
+    judge_threshold: float = 7.0  # score 0-10, pass if >= threshold
+    judge_prompt: str = ""  # custom judge prompt (optional)
 
 class TestCaseResponse(TestCaseCreate):
     id: int
@@ -16,10 +21,25 @@ class TestRunRequest(BaseModel):
     model: str = "openai/gpt-4o-mini"
     api_key: Optional[str] = None
     api_url: str = "https://openrouter.ai/api/v1"
-    system_prompt: Optional[str] = None  # override test case's system_prompt
+    system_prompt: Optional[str] = None
 
 class AgentConfig(BaseModel):
     model: str
     api_key: str
     api_url: str = "https://openrouter.ai/api/v1"
     system_prompt: str = "You are a helpful AI assistant."
+
+class JudgePrompt:
+    DEFAULT_JUDGE_PROMPT = """You are an impartial AI judge. Evaluate the response to the given prompt.
+
+Score the response on THREE dimensions (each 0-10):
+1. **accuracy** - Is the information factually correct?
+2. **relevance** - Does it directly address the user's question?
+3. **helpfulness** - Is it clear, complete, and useful?
+
+Return ONLY valid JSON with this structure:
+{{"accuracy": 8, "relevance": 9, "helpfulness": 7, "overall": 8, "reason": "brief explanation"}}
+
+Overall score is a weighted average: accuracy(40%) + relevance(30%) + helpfulness(30%).
+
+JSON OUTPUT ONLY — no markdown, no explanation outside the JSON."""

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -71,6 +71,16 @@ function showToast(message, type = 'info') {
     setTimeout(() => toast.classList.add('hidden'), 4000);
 }
 
+// --- Judge Mode Toggle ---
+function toggleJudgeFields(evalMode) {
+    const fields = document.getElementById('judge-fields');
+    if (evalMode === 'judge') {
+        fields.classList.remove('hidden');
+    } else {
+        fields.classList.add('hidden');
+    }
+}
+
 // --- Test Cases ---
 async function loadTestCases() {
     try {
@@ -101,12 +111,15 @@ function renderTestCasesFiltered(filtered) {
         <div class="card-item" onclick="showTestDetail(${tc.id})">
             <div class="card-item-header">
                 <span class="card-item-title">${escapeHtml(tc.name)}</span>
-                <button class="btn btn-primary btn-sm" onclick="event.stopPropagation(); runTestCaseFromCard(${tc.id})" title="Run this test">▶ Run</button>
-                <button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); deleteTestCase(${tc.id})">Delete</button>
+                <div class="card-item-actions">
+                    <span class="badge ${tc.eval_mode === 'judge' ? 'badge-judge' : 'badge-keyword'}">${tc.eval_mode === 'judge' ? '⚖ Judge' : '🔤 Keyword'}</span>
+                    <button class="btn btn-primary btn-sm" onclick="event.stopPropagation(); runTestCaseFromCard(${tc.id})" title="Run this test">▶ Run</button>
+                    <button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); deleteTestCase(${tc.id})">Delete</button>
+                </div>
             </div>
             ${tc.description ? `<div class="card-item-desc">${escapeHtml(tc.description)}</div>` : ''}
             <div class="card-item-meta">
-                <span>${tc.expected_keywords ? 'Keywords: ' + tc.expected_keywords : 'No keywords'}</span>
+                <span>${tc.eval_mode === 'judge' ? `Judge: ${tc.judge_model} ≥ ${tc.judge_threshold}` : (tc.expected_keywords ? 'Keywords: ' + tc.expected_keywords : 'No keywords')}</span>
                 <span>${formatDate(tc.created_at)}</span>
             </div>
         </div>
@@ -124,7 +137,11 @@ async function createTestCase(e) {
         description: document.getElementById('tc-description').value,
         input_prompt: document.getElementById('tc-prompt').value,
         expected_keywords: document.getElementById('tc-keywords').value,
-        system_prompt: document.getElementById('tc-system').value || "You are a helpful AI assistant."
+        system_prompt: document.getElementById('tc-system').value || "You are a helpful AI assistant.",
+        eval_mode: document.getElementById('tc-eval-mode').value,
+        judge_model: document.getElementById('tc-judge-model').value,
+        judge_threshold: parseFloat(document.getElementById('tc-judge-threshold').value) || 7.0,
+        judge_prompt: ''
     };
     try {
         const res = await fetch(`${API}/api/test-cases`, {
@@ -135,7 +152,9 @@ async function createTestCase(e) {
         const result = await res.json();
         hideModal('modal-create-test');
         document.getElementById('form-create-test').reset();
+        document.getElementById('judge-fields').classList.add('hidden');
         await loadTestCases();
+        showToast('Test case created!', 'success');
     } catch (e) {
         alert('Failed to create test case: ' + e.message);
     }
@@ -155,16 +174,17 @@ async function deleteTestCase(id) {
 function showTestDetail(id) {
     const tc = testCases.find(t => t.id === id);
     if (!tc) return;
+    const evalBadge = tc.eval_mode === 'judge' 
+        ? `<span class="badge badge-judge">⚖ Judge mode — ${tc.judge_model} ≥ ${tc.judge_threshold}</span>`
+        : (tc.expected_keywords ? `<span class="badge badge-keyword">🔤 Keywords: ${escapeHtml(tc.expected_keywords)}</span>` : '');
     const html = `
+        <div class="run-detail-header" style="margin-bottom:16px">
+            ${evalBadge}
+        </div>
         <div class="run-detail-section">
             <h4>Input Prompt</h4>
             <pre>${escapeHtml(tc.input_prompt)}</pre>
         </div>
-        ${tc.expected_keywords ? `
-        <div class="run-detail-section">
-            <h4>Expected Keywords</h4>
-            <pre>${escapeHtml(tc.expected_keywords)}</pre>
-        </div>` : ''}
         ${tc.system_prompt ? `
         <div class="run-detail-section">
             <h4>System Prompt</h4>
@@ -295,12 +315,14 @@ async function runSelectedTests() {
             results.push(result);
 
             const statusBadge = result.status === 'passed' ? 'badge-passed' : result.status === 'failed' ? 'badge-failed' : 'badge-error';
+            const judgeInfo = result.judge_score != null ? `<span class="judge-score" title="Judge score">⚖ ${result.judge_score}/10</span>` : '';
 
             document.getElementById(itemId).outerHTML = `
-                <div class="result-item" onclick="showRunDetail(${result.run_id})">
+                <div class="result-item" onclick="showRunDetail(${result.id})">
                     <div class="result-item-header">
                         <span class="result-item-name">${escapeHtml(tc?.name || 'Test #'+id)}</span>
                         <span class="badge ${statusBadge}">${result.status}</span>
+                        ${judgeInfo}
                     </div>
                     <div class="result-item-meta">
                         <span>${model}</span>
@@ -389,6 +411,15 @@ async function showRunDetail(runId) {
         const r = await res.json();
 
         const statusBadge = r.status === 'passed' ? 'badge-passed' : r.status === 'failed' ? 'badge-failed' : 'badge-error';
+        const judgeSection = r.judge_score != null ? `
+            <div class="run-detail-section">
+                <h4>⚖ Judge Evaluation</h4>
+                <div class="judge-score-display">
+                    <div class="judge-score-big">${r.judge_score}/10</div>
+                    <div class="judge-reason">${escapeHtml(r.judge_reason || '')}</div>
+                </div>
+            </div>
+        ` : '';
         const errorSection = r.error ? `
             <div class="run-detail-section">
                 <h4>Error</h4>
@@ -401,6 +432,7 @@ async function showRunDetail(runId) {
         const html = `
             <div class="run-detail-header">
                 <span class="badge ${statusBadge}" style="font-size:14px;padding:6px 14px">${r.status}</span>
+                ${r.judge_score != null ? `<span class="badge badge-judge">⚖ ${r.judge_score}/10</span>` : ''}
                 <span class="text-muted">${r.test_name || 'Test Run'}</span>
             </div>
             <div class="run-detail-meta">
@@ -421,11 +453,7 @@ async function showRunDetail(runId) {
                 <h4>Input Prompt</h4>
                 <pre>${escapeHtml(r.input_prompt || '')}</pre>
             </div>
-            ${r.expected_keywords ? `
-            <div class="run-detail-section">
-                <h4>Expected Keywords</h4>
-                <pre>${escapeHtml(r.expected_keywords)}</pre>
-            </div>` : ''}
+            ${judgeSection}
             <div class="run-detail-section">
                 <h4>Agent Output</h4>
                 <pre>${escapeHtml(r.output || '')}</pre>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -165,6 +165,9 @@
         </main>
     </div>
 
+    <!-- Toast notification -->
+    <div id="toast" class="toast hidden"></div>
+
     <!-- Create Test Case Modal -->
     <div id="modal-create-test" class="modal hidden">
         <div class="modal-content">
@@ -193,6 +196,30 @@
                 <div class="form-group">
                     <label for="tc-system">System Prompt</label>
                     <textarea id="tc-system" rows="3" placeholder="Optional: custom system prompt for this test">You are a helpful AI assistant.</textarea>
+                </div>
+                <div class="form-group">
+                    <label for="tc-eval-mode">Evaluation Mode</label>
+                    <select id="tc-eval-mode" onchange="toggleJudgeFields(this.value)">
+                        <option value="keyword">Keyword Match (fast, exact)</option>
+                        <option value="judge">LLM-as-Judge (slower, semantic)</option>
+                    </select>
+                    <small>Keyword: checks for exact words. Judge: uses LLM to score accuracy/relevance/helpfulness.</small>
+                </div>
+                <div id="judge-fields" class="hidden">
+                    <div class="form-group">
+                        <label for="tc-judge-model">Judge Model</label>
+                        <select id="tc-judge-model">
+                            <option value="openai/gpt-4o-mini">GPT-4o Mini (fast, cheap)</option>
+                            <option value="openai/gpt-4o">GPT-4o (slower, smarter)</option>
+                            <option value="anthropic/claude-3-5-sonnet-20250620">Claude 3.5 Sonnet</option>
+                            <option value="deepseek/deepseek-chat-v3-0324">DeepSeek V3</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="tc-judge-threshold">Pass Threshold (0-10)</label>
+                        <input type="number" id="tc-judge-threshold" value="7" min="0" max="10" step="0.5">
+                        <small>Judge scores ≥ this value = pass. Recommended: 7 for strict, 5 for lenient.</small>
+                    </div>
                 </div>
                 <div class="modal-actions">
                     <button type="button" class="btn btn-secondary" onclick="hideModal('modal-create-test')">Cancel</button>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -311,6 +311,81 @@ body {
     color: var(--yellow);
 }
 
+.badge-judge {
+    background: #7c3aed20;
+    color: #a78bfa;
+    border: 1px solid #7c3aed40;
+}
+
+.badge-keyword {
+    background: var(--cyan-bg);
+    color: var(--cyan);
+}
+
+/* Judge score display */
+.judge-score {
+    font-size: 12px;
+    color: #a78bfa;
+    margin-left: 8px;
+}
+
+.judge-score-display {
+    background: #7c3aed15;
+    border: 1px solid #7c3aed30;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.judge-score-big {
+    font-size: 32px;
+    font-weight: 700;
+    color: #a78bfa;
+    margin-bottom: 8px;
+}
+
+.judge-reason {
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+/* Toast notification */
+.toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    padding: 12px 20px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 9999;
+    transition: all 0.3s;
+}
+
+.toast-success { background: var(--green); color: #000; }
+.toast-error { background: var(--red); color: #fff; }
+.toast-info { background: var(--cyan); color: #000; }
+
+/* Card item actions */
+.card-item-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* Judge fields in form */
+#judge-fields {
+    padding: 12px;
+    background: #7c3aed10;
+    border: 1px solid #7c3aed30;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
+
+#judge-fields.hidden {
+    display: none;
+}
+
 /* Buttons */
 .btn {
     display: inline-flex;


### PR DESCRIPTION
## What this PR does

Adds a new **LLM-as-Judge** evaluation mode alongside the existing keyword matching.

### Problem with keyword matching
- Correct answers that don't contain exact keywords → false negative ❌
- Gibberish that happens to contain keywords → false positive ❌

### Solution: LLM-as-Judge
For each test run, a second LLM call ("judge") evaluates the response on three dimensions:
- **Accuracy** (0-10) — is the information correct?
- **Relevance** (0-10) — does it address the question?
- **Helpfulness** (0-10) — is it clear and complete?

The judge returns a JSON score and a reason. If overall score ≥ threshold (default 7/10), the test passes.

### New test case fields
| Field | Description |
|-------|-------------|
| `eval_mode` | `"keyword"` (default) or `"judge"` |
| `judge_model` | Model used for judging (GPT-4o Mini default) |
| `judge_threshold` | Pass threshold (default 7.0) |
| `judge_prompt` | Custom judge instructions (optional) |

### New run fields
| Field | Description |
|-------|-------------|
| `judge_score` | Overall score from judge (0-10) |
| `judge_reason` | Judge's explanation |

### Files changed
- `backend/schemas.py` — Added eval_mode, judge_model, judge_threshold, judge_prompt fields
- `backend/agent_runner.py` — Added `_evaluate_with_judge()` with JSON parsing
- `backend/db.py` — DB migrations for new columns
- `backend/main.py` — Added GET /api/test-cases/{id}, updated CRUD to pass through eval fields
- `frontend/index.html` — Judge fields UI (toggle, model selector, threshold input)
- `frontend/app.js` — Toggle function, judge data sent on create, judge score displayed in results
- `frontend/style.css` — Judge badges, judge score display, toast notification styles

### Example usage
Create a test case → select "LLM-as-Judge" → choose judge model + threshold → run. Results show ⚖ score (e.g., "⚖ 8.3/10") with the judge's reason.

### Preview

```
Test Case Card:
[⚖ Judge: gpt-4o-mini ≥ 7.0] [▶ Run] [Delete]

Run Detail:
┌─────────────────┐
│  ⚖ 8.3/10      │
│  accurate and   │
│  relevant        │
└─────────────────┘
```
